### PR TITLE
[#1] design-api-architecture

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,8 +1,583 @@
-import { describe, it, expect } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import type { InferSchemaValues, SchemaShape, TracedConfigApi, TracedConfigOptions } from '../index.js';
 
-describe('traced-config', () => {
-  it('should be importable', async () => {
-    const mod = await import('../index.js');
-    expect(mod).toBeDefined();
+type EmptySchema = Record<string, never>;
+
+async function createConfig<TSchema extends SchemaShape = EmptySchema>(
+  options: TracedConfigOptions<TSchema> = {} as TracedConfigOptions<TSchema>,
+): Promise<TracedConfigApi<InferSchemaValues<TSchema>>> {
+  const mod = (await import('../index.js')) as {
+    tracedConfig?: <TLoadedSchema extends SchemaShape = EmptySchema>(
+      loadedOptions?: TracedConfigOptions<TLoadedSchema>,
+    ) => TracedConfigApi<InferSchemaValues<TLoadedSchema>>;
+  };
+  if (typeof mod.tracedConfig !== 'function') {
+    throw new Error("Expected module to export tracedConfig(options)");
+  }
+
+  return mod.tracedConfig(options);
+}
+
+describe('traced-config API contract', () => {
+  const originalArgv = [...process.argv];
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.argv = [...originalArgv];
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.argv = [...originalArgv];
+    process.env = { ...originalEnv };
+  });
+
+  it('should export tracedConfig as a function', async () => {
+    const mod = (await import('../index.js')) as { tracedConfig?: unknown };
+
+    const exported = mod.tracedConfig;
+
+    expect(typeof exported).toBe('function');
+  });
+
+  it('should return default value and default origin for schema key', async () => {
+    const config = await createConfig({
+      schema: {
+        port: { default: 8080 },
+      },
+    });
+
+    const value = config.get('port');
+
+    expect(value).toBe(8080);
+    expect(config.getSource('port')).toBeNull();
+    expect(config.getOrigin('port')).toBe('default');
+    expect(config.getTraced('port')).toEqual({ value: 8080, source: null, origin: 'default' });
+  });
+
+  it('should allow adding schema after initialization', async () => {
+    const config = await createConfig({ envStyle: 'SCREAMING_SNAKE', argStyle: 'kebab' });
+
+    config.addSchema({
+      host: { default: 'localhost' },
+    });
+
+    expect(config.get('host')).toBe('localhost');
+  });
+
+  it('should return extended typed api from addSchema', async () => {
+    const config = await createConfig({
+      schema: {
+        host: { default: 'localhost' },
+      },
+    });
+
+    const extended = config.addSchema({
+      port: { default: 8080 },
+    });
+
+    const acceptsNumber = (value: number): number => value;
+    const acceptsString = (value: string): string => value;
+
+    expect(acceptsString(extended.get('host'))).toBe('localhost');
+    expect(acceptsNumber(extended.get('port'))).toBe(8080);
+  });
+
+  it('should infer get return types from schema default values', async () => {
+    const config = await createConfig({
+      schema: {
+        port: { default: 8080 },
+        host: { default: 'localhost' },
+      },
+    });
+
+    const acceptsNumber = (value: number): number => value;
+    const acceptsString = (value: string): string => value;
+    const port = config.get('port');
+    const host = config.get('host');
+
+    expect(acceptsNumber(port)).toBe(8080);
+    expect(acceptsString(host)).toBe('localhost');
+  });
+
+  it('should throw when addSchema defines duplicate key', async () => {
+    const config = await createConfig({
+      schema: {
+        port: { default: 8080 },
+      },
+    });
+
+    expect(() => {
+      config.addSchema({
+        port: { default: 3000 },
+      });
+    }).toThrow(/Schema key 'port' is already defined/);
+  });
+
+  it('should throw when get is called with undefined schema key', async () => {
+    const config = await createConfig({ schema: { port: { default: 8080 } } });
+
+    expect(() => config.get('missingKey')).toThrow();
+  });
+
+  it('should reject nested schema key names', async () => {
+    const config = await createConfig({});
+
+    expect(() => {
+      config.addSchema({
+        'db.host': { default: 'localhost' },
+      });
+    }).toThrow();
+  });
+
+  it('should require object entries with label in loadFile', async () => {
+    const config = await createConfig({ schema: { port: { default: 8080 } } });
+
+    await expect(config.loadFile(['./config.yaml' as unknown as { path: string; label: 'global' | 'local' }])).rejects.toThrow();
+  });
+
+  it('should skip missing files in loadFile', async () => {
+    const config = await createConfig({ schema: { port: { default: 8080 } } });
+
+    await expect(config.loadFile([{ path: '/path/does/not/exist.yaml', label: 'global' }])).resolves.toBeUndefined();
+
+    expect(config.get('port')).toBe(8080);
+  });
+
+  it('should load YAML and JSON files in order and prefer later file', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'traced-config-test-'));
+    const globalFile = join(dir, 'global.yaml');
+    const localFile = join(dir, 'config.json');
+    await writeFile(globalFile, 'port: 8080\nhost: global.example\n', 'utf8');
+    await writeFile(localFile, JSON.stringify({ port: 9090 }), 'utf8');
+
+    const config = await createConfig({
+      schema: {
+        port: { default: 3000 },
+        host: { default: 'localhost' },
+      },
+    });
+
+    await config.loadFile([
+      { path: globalFile, label: 'global' },
+      { path: localFile, label: 'local' },
+    ]);
+
+    expect(config.get('port')).toBe(9090);
+    expect(config.get('host')).toBe('global.example');
+    expect(config.getOrigin('port')).toBe('local');
+    expect(config.getSource('port')).toBe(localFile);
+
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('should mark loaded value origin and source as global when only global file provides it', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'traced-config-test-'));
+    const globalFile = join(dir, 'global.yaml');
+    await writeFile(globalFile, 'port: 8080\n', 'utf8');
+
+    const config = await createConfig({
+      schema: {
+        port: { default: 3000, format: 'port' },
+      },
+    });
+
+    await config.loadFile([{ path: globalFile, label: 'global' }]);
+
+    expect(config.get('port')).toBe(8080);
+    expect(config.getOrigin('port')).toBe('global');
+    expect(config.getSource('port')).toBe(globalFile);
+    expect(config.getTraced('port')).toEqual({ value: 8080, source: globalFile, origin: 'global' });
+
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('should prioritize env over local/global/default when env source is enabled', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'traced-config-test-'));
+    const localFile = join(dir, 'config.json');
+    await writeFile(localFile, JSON.stringify({ port: 9090 }), 'utf8');
+
+    process.env.PORT = '7070';
+
+    const config = await createConfig({
+      schema: {
+        port: {
+          default: 3000,
+          format: 'port',
+          sources: { global: true, local: true, env: true, cli: false },
+        },
+      },
+    });
+
+    await config.loadFile([{ path: localFile, label: 'local' }]);
+
+    expect(config.get('port')).toBe(7070);
+    expect(config.getOrigin('port')).toBe('env');
+    expect(config.getSource('port')).toBe('PORT');
+
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('should keep cli disabled by default', async () => {
+    process.argv = ['node', 'test', '--port', '9191'];
+    const config = await createConfig({
+      schema: {
+        port: { default: 8080, format: 'port' },
+      },
+    });
+
+    const value = config.get('port');
+
+    expect(value).toBe(8080);
+    expect(config.getOrigin('port')).toBe('default');
+  });
+
+  it('should prioritize cli over env when cli source is enabled', async () => {
+    process.env.PORT = '7070';
+    process.argv = ['node', 'test', '--port', '9191'];
+
+    const config = await createConfig({
+      schema: {
+        port: {
+          default: 3000,
+          format: 'port',
+          sources: { global: true, local: true, env: true, cli: true },
+        },
+      },
+    });
+
+    const value = config.get('port');
+
+    expect(value).toBe(9191);
+    expect(config.getOrigin('port')).toBe('cli');
+    expect(config.getSource('port')).toBe('--port');
+  });
+
+  it('should apply default < global < local < env < cli precedence chain', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'traced-config-test-'));
+    const globalFile = join(dir, 'global.yaml');
+    const localFile = join(dir, 'local.json');
+    await writeFile(globalFile, 'port: 4000\n', 'utf8');
+    await writeFile(localFile, JSON.stringify({ port: 5000 }), 'utf8');
+
+    process.env.PORT = '6000';
+    process.argv = ['node', 'test', '--port', '7000'];
+
+    const config = await createConfig({
+      schema: {
+        port: {
+          default: 3000,
+          format: 'port',
+          sources: { global: true, local: true, env: true, cli: true },
+        },
+      },
+    });
+
+    await config.loadFile([
+      { path: globalFile, label: 'global' },
+      { path: localFile, label: 'local' },
+    ]);
+
+    expect(config.get('port')).toBe(7000);
+    expect(config.getOrigin('port')).toBe('cli');
+    expect(config.getSource('port')).toBe('--port');
+
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('should ignore env value when env source is disabled', async () => {
+    process.env.PORT = '7070';
+    const config = await createConfig({
+      schema: {
+        port: {
+          default: 8080,
+          format: 'port',
+          sources: { global: true, local: true, env: false, cli: false },
+        },
+      },
+    });
+
+    const value = config.get('port');
+
+    expect(value).toBe(8080);
+    expect(config.getOrigin('port')).toBe('default');
+  });
+
+  it('should auto-generate env and arg names from camelCase key', async () => {
+    process.env.TAKT_ANTHROPIC_API_KEY = 'env-secret';
+    const config = await createConfig({
+      schema: {
+        taktAnthropicApiKey: { default: '', sources: { global: true, local: true, env: true, cli: false } },
+      },
+    });
+
+    const value = config.get('taktAnthropicApiKey');
+
+    expect(value).toBe('env-secret');
+    expect(config.getSource('taktAnthropicApiKey')).toBe('TAKT_ANTHROPIC_API_KEY');
+    expect(config.getOrigin('taktAnthropicApiKey')).toBe('env');
+  });
+
+  it('should prioritize manually configured env name over auto-generated name', async () => {
+    process.env.CUSTOM_PORT = '7331';
+    process.env.PORT = '8081';
+
+    const config = await createConfig({
+      schema: {
+        port: {
+          default: 8080,
+          format: 'port',
+          env: 'CUSTOM_PORT',
+          sources: { global: true, local: true, env: true, cli: false },
+        },
+      },
+    });
+
+    const value = config.get('port');
+
+    expect(value).toBe(7331);
+    expect(config.getSource('port')).toBe('CUSTOM_PORT');
+    expect(config.getOrigin('port')).toBe('env');
+  });
+
+  it('should prioritize manually configured arg name over auto-generated name', async () => {
+    process.argv = ['node', 'test', '--custom-port', '7331', '--port', '8081'];
+
+    const config = await createConfig({
+      schema: {
+        port: {
+          default: 8080,
+          format: 'port',
+          arg: 'custom-port',
+          sources: { global: true, local: true, env: true, cli: true },
+        },
+      },
+    });
+
+    expect(config.get('port')).toBe(7331);
+    expect(config.getSource('port')).toBe('--custom-port');
+    expect(config.getOrigin('port')).toBe('cli');
+  });
+
+  it('should split comma-separated env value for Array format', async () => {
+    process.env.TAGS = 'a,b,c';
+    const config = await createConfig({
+      schema: {
+        tags: { default: [] as string[], format: Array, env: 'TAGS', sources: { global: true, local: true, env: true, cli: false } },
+      },
+    });
+
+    const value = config.get('tags');
+
+    expect(value).toEqual(['a', 'b', 'c']);
+    expect(config.getOrigin('tags')).toBe('env');
+  });
+
+  it('should split comma-separated cli value for Array format', async () => {
+    process.argv = ['node', 'test', '--tags', 'red,green,blue'];
+    const config = await createConfig({
+      schema: {
+        tags: { default: [] as string[], format: Array, sources: { global: true, local: true, env: true, cli: true } },
+      },
+    });
+
+    const value = config.get('tags');
+
+    expect(value).toEqual(['red', 'green', 'blue']);
+    expect(config.getSource('tags')).toBe('--tags');
+    expect(config.getOrigin('tags')).toBe('cli');
+  });
+
+  it('should return format validation errors from validate()', async () => {
+    process.env.PORT = '-1';
+    const config = await createConfig({
+      schema: {
+        port: { default: 8080, format: 'port', sources: { global: true, local: true, env: true, cli: false } },
+      },
+    });
+
+    const errors = config.validate();
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({ key: 'port', value: -1 });
+    expect(typeof errors[0]?.message).toBe('string');
+  });
+
+  it('should validate enum format values', async () => {
+    process.env.NODE_ENV = 'staging';
+    const config = await createConfig({
+      schema: {
+        nodeEnv: {
+          default: 'development',
+          format: ['production', 'development', 'test'],
+          env: 'NODE_ENV',
+          sources: { global: true, local: true, env: true, cli: false },
+        },
+      },
+    });
+
+    const errors = config.validate();
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({ key: 'nodeEnv', value: 'staging' });
+  });
+
+  it('should register custom parser and load custom extension file', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'traced-config-test-'));
+    const customFile = join(dir, 'custom.cfg');
+    await writeFile(customFile, 'port=7345\nhost=custom.example\n', 'utf8');
+
+    const config = await createConfig({
+      schema: {
+        port: { default: 8080, format: 'port' },
+        host: { default: 'localhost' },
+      },
+    });
+
+    config.addParser('cfg', (content) => {
+      const parsed: Record<string, string> = {};
+      for (const line of content.split('\n')) {
+        const [rawKey, rawValue] = line.split('=');
+        if (!rawKey || !rawValue) {
+          continue;
+        }
+        parsed[rawKey.trim()] = rawValue.trim();
+      }
+      return parsed;
+    });
+
+    await config.loadFile([{ path: customFile, label: 'local' }]);
+
+    expect(config.get('port')).toBe('7345');
+    expect(config.get('host')).toBe('custom.example');
+    expect(config.getOrigin('port')).toBe('local');
+
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('should register custom format and validate with it', async () => {
+    const config = await createConfig({
+      schema: {
+        evenValue: { default: 3, format: 'isEven' },
+      },
+    });
+
+    config.addFormat('isEven', (value) => typeof value === 'number' && value % 2 === 0);
+
+    const errors = config.validate();
+
+    expect(errors).toEqual([
+      expect.objectContaining({
+        key: 'evenValue',
+        value: 3,
+        message: 'isEven validation failed',
+      }),
+    ]);
+  });
+
+  it('should validate nat format values', async () => {
+    process.env.NAT_VALUE = '-1';
+    const config = await createConfig({
+      schema: {
+        natValue: { default: 1, format: 'nat', env: 'NAT_VALUE', sources: { global: true, local: true, env: true, cli: false } },
+      },
+    });
+
+    expect(config.get('natValue')).toBe(-1);
+    const errors = config.validate();
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({ key: 'natValue', value: -1, message: 'nat must be a non-negative integer' });
+  });
+
+  it('should validate int format values', async () => {
+    process.env.INT_VALUE = '1.5';
+    const config = await createConfig({
+      schema: {
+        intValue: { default: 2, format: 'int', env: 'INT_VALUE', sources: { global: true, local: true, env: true, cli: false } },
+      },
+    });
+
+    expect(config.get('intValue')).toBe(1.5);
+    const errors = config.validate();
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({ key: 'intValue', value: 1.5, message: 'int must be an integer' });
+  });
+
+  it('should validate url format values', async () => {
+    process.env.APP_URL = 'not-a-url';
+    const config = await createConfig({
+      schema: {
+        appUrl: { default: 'https://example.com', format: 'url', env: 'APP_URL', sources: { global: true, local: true, env: true, cli: false } },
+      },
+    });
+
+    expect(config.get('appUrl')).toBe('not-a-url');
+    const errors = config.validate();
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({ key: 'appUrl', value: 'not-a-url', message: 'url must be a valid URL' });
+  });
+
+  it('should validate ipaddress format values', async () => {
+    process.env.HOST_IP = '999.1.1.1';
+    const config = await createConfig({
+      schema: {
+        hostIp: { default: '127.0.0.1', format: 'ipaddress', env: 'HOST_IP', sources: { global: true, local: true, env: true, cli: false } },
+      },
+    });
+
+    expect(config.get('hostIp')).toBe('999.1.1.1');
+    const errors = config.validate();
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]).toMatchObject({ key: 'hostIp', value: '999.1.1.1', message: 'ipaddress must be a valid IPv4 or IPv6 address' });
+  });
+
+  it('should include unknown keys with source and origin in strict validation', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'traced-config-test-'));
+    const globalFile = join(dir, 'global.yaml');
+    await writeFile(globalFile, 'port: 8080\ntypoKey: true\n', 'utf8');
+
+    const config = await createConfig({
+      schema: {
+        port: { default: 3000, format: 'port' },
+      },
+    });
+    await config.loadFile([{ path: globalFile, label: 'global' }]);
+
+    const errors = config.validate({ strict: true });
+
+    expect(errors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ key: 'typoKey', source: globalFile, origin: 'global' }),
+      ]),
+    );
+
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it('should not include unknown keys in non-strict validation', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'traced-config-test-'));
+    const localFile = join(dir, 'config.json');
+    await writeFile(localFile, JSON.stringify({ unknownFlag: true }), 'utf8');
+
+    const config = await createConfig({
+      schema: {
+        port: { default: 3000, format: 'port' },
+      },
+    });
+    await config.loadFile([{ path: localFile, label: 'local' }]);
+
+    const errors = config.validate();
+
+    expect(errors).toEqual([]);
+
+    await rm(dir, { recursive: true, force: true });
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,31 @@
+import type { CliValue } from './types.js';
+
+export function parseCli(argv: string[]): Map<string, CliValue> {
+  const parsed = new Map<string, CliValue>();
+
+  for (let index = 2; index < argv.length; index += 1) {
+    const token = argv[index];
+    if (!token || !token.startsWith('--')) {
+      continue;
+    }
+
+    const equalIndex = token.indexOf('=');
+    if (equalIndex !== -1) {
+      const name = token.slice(0, equalIndex);
+      const value = token.slice(equalIndex + 1);
+      parsed.set(name, { value, source: name });
+      continue;
+    }
+
+    const next = argv[index + 1];
+    if (typeof next === 'string' && !next.startsWith('--')) {
+      parsed.set(token, { value: next, source: token });
+      index += 1;
+      continue;
+    }
+
+    parsed.set(token, { value: 'true', source: token });
+  }
+
+  return parsed;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,11 @@
-// traced-config — Configuration management with key-level source tracing.
+export { tracedConfig } from './traced-config.js';
+export type {
+  InferSchemaValues,
+  Origin,
+  SchemaEntry,
+  SchemaShape,
+  TracedConfigApi,
+  TracedConfigOptions,
+  TracedValue,
+  ValidateError,
+} from './types.js';

--- a/src/naming.ts
+++ b/src/naming.ts
@@ -1,0 +1,35 @@
+export function toScreamingSnake(input: string): string {
+  return input
+    .replace(/([a-z0-9])([A-Z])/g, '$1_$2')
+    .replace(/([A-Z])([A-Z][a-z])/g, '$1_$2')
+    .replace(/[\s-]+/g, '_')
+    .toUpperCase();
+}
+
+export function toKebab(input: string): string {
+  return input
+    .replace(/([a-z0-9])([A-Z])/g, '$1-$2')
+    .replace(/([A-Z])([A-Z][a-z])/g, '$1-$2')
+    .replace(/[\s_]+/g, '-')
+    .toLowerCase();
+}
+
+const ENV_NAME_BUILDERS = {
+  SCREAMING_SNAKE: toScreamingSnake,
+} as const;
+
+const ARG_NAME_BUILDERS = {
+  kebab: (key: string) => `--${toKebab(key)}`,
+} as const;
+
+export function buildDefaultEnvName(key: string, envStyle: keyof typeof ENV_NAME_BUILDERS): string {
+  return ENV_NAME_BUILDERS[envStyle](key);
+}
+
+export function buildDefaultArgName(key: string, argStyle: keyof typeof ARG_NAME_BUILDERS): string {
+  return ARG_NAME_BUILDERS[argStyle](key);
+}
+
+export function normalizeArgName(argName: string): string {
+  return argName.startsWith('--') ? argName : `--${argName}`;
+}

--- a/src/traced-config.ts
+++ b/src/traced-config.ts
@@ -1,0 +1,267 @@
+import { access, readFile } from 'node:fs/promises';
+import { constants } from 'node:fs';
+import { parseCli } from './cli.js';
+import { buildDefaultArgName, buildDefaultEnvName, normalizeArgName } from './naming.js';
+import type {
+  FileLabel,
+  FileParser,
+  FileValueRecord,
+  FormatValidator,
+  InferSchemaValues,
+  Origin,
+  ResolvedSchemaEntry,
+  SchemaShape,
+  SourceToggles,
+  TracedConfigApi,
+  TracedConfigOptions,
+  TracedValue,
+  UnknownKeyIssue,
+  ValidateError,
+} from './types.js';
+import { createDefaultParsers, getFileExtension, isMissingFileError, isPlainObject } from './utils.js';
+import { coerceInputValue, validateFormatValue } from './validation.js';
+
+const DEFAULT_SOURCES: SourceToggles = {
+  global: true,
+  local: true,
+  env: true,
+  cli: false,
+};
+
+export function tracedConfig<TSchema extends SchemaShape = {}>(
+  options: TracedConfigOptions<TSchema> = {},
+): TracedConfigApi<InferSchemaValues<TSchema>> {
+  const envStyle = options.envStyle ?? 'SCREAMING_SNAKE';
+  const argStyle = options.argStyle ?? 'kebab';
+  const schema = new Map<string, ResolvedSchemaEntry>();
+  const globalValues = new Map<string, FileValueRecord>();
+  const localValues = new Map<string, FileValueRecord>();
+  const unknownFileKeys: UnknownKeyIssue[] = [];
+  const parsers = createDefaultParsers();
+  const customFormats = new Map<string, FormatValidator>();
+
+  function assertKnownKey(key: string): ResolvedSchemaEntry {
+    const entry = schema.get(key);
+    if (!entry) {
+      throw new Error(`Schema key '${key}' is not defined`);
+    }
+
+    return entry;
+  }
+
+  function resolveKey(key: string): TracedValue<unknown> {
+    const entry = assertKnownKey(key);
+
+    let traced: TracedValue<unknown> = {
+      value: entry.default,
+      source: null,
+      origin: 'default',
+    };
+
+    if (entry.sources.global) {
+      const fromGlobal = globalValues.get(key);
+      if (fromGlobal) {
+        traced = { value: fromGlobal.value, source: fromGlobal.source, origin: 'global' };
+      }
+    }
+
+    if (entry.sources.local) {
+      const fromLocal = localValues.get(key);
+      if (fromLocal) {
+        traced = { value: fromLocal.value, source: fromLocal.source, origin: 'local' };
+      }
+    }
+
+    if (entry.sources.env) {
+      const envValue = process.env[entry.env];
+      if (envValue !== undefined) {
+        traced = {
+          value: coerceInputValue(envValue, entry),
+          source: entry.env,
+          origin: 'env',
+        };
+      }
+    }
+
+    if (entry.sources.cli) {
+      const cliValues = parseCli(process.argv);
+      const cliValue = cliValues.get(entry.arg);
+      if (cliValue) {
+        traced = {
+          value: coerceInputValue(cliValue.value, entry),
+          source: cliValue.source,
+          origin: 'cli',
+        };
+      }
+    }
+
+    return traced;
+  }
+
+  function addSchema<TNextSchema extends SchemaShape>(
+    next: TNextSchema,
+  ): TracedConfigApi<Record<string, unknown> & InferSchemaValues<TNextSchema>> {
+    for (const [key, rawEntry] of Object.entries(next)) {
+      if (key.includes('.')) {
+        throw new Error(`Nested schema keys are not supported: '${key}'`);
+      }
+
+      if (schema.has(key)) {
+        throw new Error(`Schema key '${key}' is already defined`);
+      }
+
+      const env = rawEntry.env ?? buildDefaultEnvName(key, envStyle);
+      const arg = rawEntry.arg ?? buildDefaultArgName(key, argStyle);
+      const sources: SourceToggles = {
+        ...DEFAULT_SOURCES,
+        ...(rawEntry.sources ?? {}),
+      };
+
+      schema.set(key, {
+        default: rawEntry.default,
+        format: rawEntry.format,
+        env,
+        arg: normalizeArgName(arg),
+        sources,
+      });
+    }
+
+    return api as unknown as TracedConfigApi<Record<string, unknown> & InferSchemaValues<TNextSchema>>;
+  }
+
+  function addParser(extension: string, parser: FileParser): void {
+    if (typeof extension !== 'string' || extension.trim().length === 0) {
+      throw new Error('Parser extension must be a non-empty string');
+    }
+
+    if (typeof parser !== 'function') {
+      throw new Error('Parser must be a function');
+    }
+
+    const normalized = extension.replace(/^\./, '').toLowerCase();
+    parsers.set(normalized, parser);
+  }
+
+  function addFormat(name: string, validator: FormatValidator): void {
+    if (typeof name !== 'string' || name.trim().length === 0) {
+      throw new Error('Format name must be a non-empty string');
+    }
+
+    if (typeof validator !== 'function') {
+      throw new Error('Format validator must be a function');
+    }
+
+    customFormats.set(name, validator);
+  }
+
+  async function loadFile(entries: Array<{ path: string; label: FileLabel }>): Promise<void> {
+    for (const entry of entries) {
+      if (!isPlainObject(entry) || typeof entry.path !== 'string' || (entry.label !== 'global' && entry.label !== 'local')) {
+        throw new Error('loadFile entries must be objects with { path, label } where label is global or local');
+      }
+
+      try {
+        await access(entry.path, constants.F_OK);
+      } catch (error) {
+        if (isMissingFileError(error)) {
+          continue;
+        }
+
+        throw error;
+      }
+
+      const content = await readFile(entry.path, 'utf8');
+      const extension = getFileExtension(entry.path);
+      const parser = parsers.get(extension);
+      if (!parser) {
+        throw new Error(`Unsupported file type for path: ${entry.path}`);
+      }
+
+      const parsedRaw = parser(content);
+      const parsed = isPlainObject(parsedRaw) ? parsedRaw : {};
+
+      for (const [key, value] of Object.entries(parsed)) {
+        if (!schema.has(key)) {
+          unknownFileKeys.push({ key, source: entry.path, origin: entry.label });
+          continue;
+        }
+
+        if (entry.label === 'global') {
+          globalValues.set(key, { value, source: entry.path });
+        } else {
+          localValues.set(key, { value, source: entry.path });
+        }
+      }
+    }
+  }
+
+  function get(key: string): unknown {
+    return resolveKey(key).value;
+  }
+
+  function getSource(key: string): string | null {
+    return resolveKey(key).source;
+  }
+
+  function getOrigin(key: string): Origin {
+    return resolveKey(key).origin;
+  }
+
+  function getTraced(key: string): TracedValue<unknown> {
+    return resolveKey(key);
+  }
+
+  function validate(validateOptions: { strict?: boolean } = {}): ValidateError[] {
+    const errors: ValidateError[] = [];
+
+    for (const [key, entry] of schema.entries()) {
+      const resolved = resolveKey(key);
+      let error = validateFormatValue(key, resolved.value, entry.format);
+      if (!error && typeof entry.format === 'string') {
+        const validator = customFormats.get(entry.format);
+        if (validator && !validator(resolved.value)) {
+          error = {
+            key,
+            value: resolved.value,
+            message: `${entry.format} validation failed`,
+          };
+        }
+      }
+
+      if (error) {
+        errors.push(error);
+      }
+    }
+
+    if (validateOptions.strict) {
+      for (const unknown of unknownFileKeys) {
+        errors.push({
+          key: unknown.key,
+          source: unknown.source,
+          origin: unknown.origin,
+          message: `Unknown key '${unknown.key}'`,
+        });
+      }
+    }
+
+    return errors;
+  }
+
+  const api: TracedConfigApi<Record<string, unknown>> = {
+    addSchema,
+    addParser,
+    addFormat,
+    loadFile,
+    get,
+    getSource,
+    getOrigin,
+    getTraced,
+    validate,
+  };
+
+  if (options.schema) {
+    addSchema(options.schema);
+  }
+
+  return api as unknown as TracedConfigApi<InferSchemaValues<TSchema>>;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,82 @@
+export type Origin = 'default' | 'global' | 'local' | 'env' | 'cli';
+export type FileLabel = 'global' | 'local';
+
+export type SourceToggles = {
+  global: boolean;
+  local: boolean;
+  env: boolean;
+  cli: boolean;
+};
+
+export type SchemaEntry<TDefault> = {
+  default: TDefault;
+  format?: unknown;
+  env?: string;
+  arg?: string;
+  sources?: Partial<SourceToggles>;
+};
+
+export type SchemaShape = Record<string, SchemaEntry<unknown>>;
+
+export type InferSchemaValues<TSchema extends SchemaShape> = {
+  [K in keyof TSchema]: TSchema[K]['default'];
+};
+
+export type TracedValue<TValue> = {
+  value: TValue;
+  source: string | null;
+  origin: Origin;
+};
+
+export type ValidateError = {
+  key: string;
+  value?: unknown;
+  source?: string | null;
+  origin?: string;
+  message?: string;
+};
+
+export type TracedConfigOptions<TSchema extends SchemaShape = {}> = {
+  envStyle?: 'SCREAMING_SNAKE';
+  argStyle?: 'kebab';
+  schema?: TSchema;
+};
+
+export type FileParser = (content: string) => unknown;
+export type FormatValidator = (value: unknown) => boolean;
+
+export type ResolvedSchemaEntry = {
+  default: unknown;
+  format?: unknown;
+  env: string;
+  arg: string;
+  sources: SourceToggles;
+};
+
+export type FileValueRecord = {
+  value: unknown;
+  source: string;
+};
+
+export type CliValue = {
+  value: string;
+  source: string;
+};
+
+export type UnknownKeyIssue = {
+  key: string;
+  source: string;
+  origin: FileLabel;
+};
+
+export type TracedConfigApi<TValues extends Record<string, unknown>> = {
+  addSchema: <TSchema extends SchemaShape>(schema: TSchema) => TracedConfigApi<TValues & InferSchemaValues<TSchema>>;
+  addParser: (extension: string, parser: FileParser) => void;
+  addFormat: (name: string, validator: FormatValidator) => void;
+  loadFile: (entries: Array<{ path: string; label: FileLabel }>) => Promise<void>;
+  get: <TKey extends Extract<keyof TValues, string>>(key: TKey) => TValues[TKey];
+  getSource: <TKey extends Extract<keyof TValues, string>>(key: TKey) => string | null;
+  getOrigin: <TKey extends Extract<keyof TValues, string>>(key: TKey) => Origin;
+  getTraced: <TKey extends Extract<keyof TValues, string>>(key: TKey) => TracedValue<TValues[TKey]>;
+  validate: (options?: { strict?: boolean }) => ValidateError[];
+};

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,31 @@
+import type { FileParser } from './types.js';
+import YAML from 'yaml';
+
+export function isMissingFileError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+
+  return 'code' in error && (error as NodeJS.ErrnoException).code === 'ENOENT';
+}
+
+export function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+export function getFileExtension(filePath: string): string {
+  const lastDot = filePath.lastIndexOf('.');
+  if (lastDot === -1 || lastDot === filePath.length - 1) {
+    throw new Error(`Unsupported file type for path: ${filePath}`);
+  }
+
+  return filePath.slice(lastDot + 1).toLowerCase();
+}
+
+export function createDefaultParsers(): Map<string, FileParser> {
+  return new Map<string, FileParser>([
+    ['yaml', (content: string) => YAML.parse(content)],
+    ['yml', (content: string) => YAML.parse(content)],
+    ['json', (content: string) => JSON.parse(content) as unknown],
+  ]);
+}

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,0 +1,123 @@
+import type { ResolvedSchemaEntry, ValidateError } from './types.js';
+
+export function coerceInputValue(value: unknown, entry: ResolvedSchemaEntry): unknown {
+  if (typeof value !== 'string') {
+    return value;
+  }
+
+  if (entry.format === Array) {
+    return value.split(',').map((part) => part.trim());
+  }
+
+  if (entry.format === Number || entry.format === 'port' || entry.format === 'nat' || entry.format === 'int') {
+    const parsed = Number(value);
+    return Number.isNaN(parsed) ? value : parsed;
+  }
+
+  if (entry.format === Boolean) {
+    if (value === 'true' || value === '1') {
+      return true;
+    }
+
+    if (value === 'false' || value === '0') {
+      return false;
+    }
+
+    return value;
+  }
+
+  if (entry.format === String) {
+    return value;
+  }
+
+  if (Array.isArray(entry.default)) {
+    return value.split(',').map((part) => part.trim());
+  }
+
+  if (typeof entry.default === 'number') {
+    const parsed = Number(value);
+    return Number.isNaN(parsed) ? value : parsed;
+  }
+
+  if (typeof entry.default === 'boolean') {
+    if (value === 'true' || value === '1') {
+      return true;
+    }
+
+    if (value === 'false' || value === '0') {
+      return false;
+    }
+  }
+
+  return value;
+}
+
+export function validateFormatValue(key: string, value: unknown, format: unknown): ValidateError | null {
+  if (format === undefined) {
+    return null;
+  }
+
+  if (Array.isArray(format)) {
+    if (!format.includes(value)) {
+      return { key, value, message: `Value must be one of: ${format.join(', ')}` };
+    }
+
+    return null;
+  }
+
+  if (format === String) {
+    return typeof value === 'string' ? null : { key, value, message: 'Value must be a string' };
+  }
+
+  if (format === Number) {
+    return typeof value === 'number' && Number.isFinite(value) ? null : { key, value, message: 'Value must be a number' };
+  }
+
+  if (format === Boolean) {
+    return typeof value === 'boolean' ? null : { key, value, message: 'Value must be a boolean' };
+  }
+
+  if (format === Array) {
+    return Array.isArray(value) ? null : { key, value, message: 'Value must be an array' };
+  }
+
+  if (format === 'port') {
+    const valid = typeof value === 'number' && Number.isInteger(value) && value >= 0 && value <= 65535;
+    return valid ? null : { key, value, message: 'port must be 0-65535' };
+  }
+
+  if (format === 'nat') {
+    const valid = typeof value === 'number' && Number.isInteger(value) && value >= 0;
+    return valid ? null : { key, value, message: 'nat must be a non-negative integer' };
+  }
+
+  if (format === 'int') {
+    const valid = typeof value === 'number' && Number.isInteger(value);
+    return valid ? null : { key, value, message: 'int must be an integer' };
+  }
+
+  if (format === 'url') {
+    if (typeof value !== 'string') {
+      return { key, value, message: 'url must be a string' };
+    }
+
+    try {
+      new URL(value);
+      return null;
+    } catch {
+      return { key, value, message: 'url must be a valid URL' };
+    }
+  }
+
+  if (format === 'ipaddress') {
+    if (typeof value !== 'string') {
+      return { key, value, message: 'ipaddress must be a string' };
+    }
+
+    const ipv4 = /^(25[0-5]|2[0-4]\d|1?\d?\d)(\.(25[0-5]|2[0-4]\d|1?\d?\d)){3}$/;
+    const ipv6 = /^(([0-9a-fA-F]{1,4}:){7}[0-9a-fA-F]{1,4}|::1|::)$/;
+    return ipv4.test(value) || ipv6.test(value) ? null : { key, value, message: 'ipaddress must be a valid IPv4 or IPv6 address' };
+  }
+
+  return null;
+}


### PR DESCRIPTION
## Summary

## Overview

traced-config は「キー単位で値の由来（origin）を追跡できる」コンフィグライブラリ。
既存ライブラリ（convict, nconf, node-config 等）にはない機能を提供する。

## API

### 初期化

```typescript
// スキーマなしで初期化（後から addSchema）
const config = tracedConfig({
  envStyle: 'SCREAMING_SNAKE',  // default。キー名 → 環境変数名の変換スタイル
  argStyle: 'kebab',            // default。キー名 → CLI引数名の変換スタイル
});

// スキーマ付きで初期化も可能
const config = tracedConfig({
  envStyle: 'SCREAMING_SNAKE',
  argStyle: 'kebab',
  schema: {
    port: { default: 8080 },
    host: { default: 'localhost' },
  },
});
```

### スキーマ定義

```typescript
config.addSchema({
  taktAnthropicApiKey: {
    default: '',
    // env 自動生成: TAKT_ANTHROPIC_API_KEY
    // arg 自動生成: --takt-anthropic-api-key
  },
  port: {
    doc: 'The port to bind',
    format: 'port',
    default: 8080,
    env: 'PORT',          // 手動指定で自動生成を上書き
    arg: 'port',          // 手動指定で自動生成を上書き
    sources: {            // ソースごとの有効/無効
      global: true,       // default true
      local: true,        // default true
      env: true,          // default true
      cli: false,         // default false
    },
  },
});

// 後から追加OK
config.addSchema({
  logLevel: { default: 'info' },
});

// 同じキーの再定義はエラー
config.addSchema({
  port: { default: 3000 },  // throws Error: Schema key 'port' is already defined
});
```

### 型推論

`default` の値から TypeScript が型を推論する。

```typescript
config.addSchema({
  port: { default: 8080 },            // get('port') → number
  host: { default: 'localhost' },     // get('host') → string
  debug: { default: false },          // get('debug') → boolean
  tags: { default: [] as string[] },  // get('tags') → string[]
});
```

### ファイル読み込み

```typescript
config.loadFile([
  { path: '~/.myapp/config.yaml', label: 'global' },
  { path: './config.json', label: 'local' },
]);
```

- label は必須（文字列だけの指定はエラー）
- YAML と JSON を組み込みサポート（拡張子で自動判別）
- 複数ファイルを順序付きでロード（後勝ち）
- 追加パーサー登録可能（TOML 等）
- ファイルが存在しない場合は skip

### 値の取得

```typescript
config.get('port');           // 8080（値のみ、型推論あり）
config.getSource('port');     // '/path/to/config.yaml'（ファイルパス, env変数名, '--arg名', or null）
config.getOrigin('port');     // 'local'（'default' | 'global' | 'local' | 'env' | 'cli'）
config.getTraced('port');     // { value: 8080, source: '/path/to/config.yaml', origin: 'local' }
```

未定義キーを `get()` に渡した場合はエラー。

### source / origin の値

| origin | source の値 |
|--------|------------|
| `'default'` | `null` |
| `'global'` | ファイルパス（例: `'/Users/nrs/.myapp/config.yaml'`） |
| `'local'` | ファイルパス（例: `'./config.json'`） |
| `'env'` | 環境変数名（例: `'PORT'`） |
| `'cli'` | CLI引数名（例: `'--port'`） |

### デフォルト優先順位

`default < global < local < env < cli`

env/cli はスキーマの `sources` で制御。`cli` はデフォルト OFF。

### 配列の扱い

format が `Array` の場合、env / cli の文字列値はカンマ区切りで自動 split する。

```
FOO=a,b,c        → ['a', 'b', 'c']
--foo a,b,c      → ['a', 'b', 'c']
```

### バリデーション

```typescript
// フォーマットバリデーション：全キーの値をスキーマの format に対して検証
const formatErrors = config.validate();
// => [] （エラーなし）
// => [{ key: 'port', value: -1, message: 'port must be 0-65535' }]

// strict バリデーション：設定ファイルにスキーマ未定義のキーがあればエラー一覧を返す
const unknownKeys = config.validate({ strict: true });
// => [{ key: 'typoKey', source: '/path/to/config.yaml', origin: 'local' },
//     { key: 'oldSetting', source: '~/.myapp/config.yaml', origin: 'global' }]
```

- `validate()` — フォーマット検証のみ
- `validate({ strict: true })` — フォーマット検証 + 未定義キーの検出
- 未定義キーのエラーには source / origin 付きでどのファイルに問題があるか特定可能

#### 組み込みフォーマット

- `port` (0-65535), `nat` (>=0), `int`, `url`, `ipaddress`
- JS コンストラクタ: `String`, `Number`, `Boolean`, `Array`
- 列挙型: `['production', 'development', 'test']`
- カスタムフォーマット登録

### env/arg 名の自動生成

スキーマのキー名からスタイルに従って自動生成。`env` / `arg` を手動指定すれば上書き。

| キー名 | envStyle: SCREAMING_SNAKE | argStyle: kebab |
|--------|--------------------------|-----------------|
| `taktAnthropicApiKey` | `TAKT_ANTHROPIC_API_KEY` | `--takt-anthropic-api-key` |
| `dbHost` | `DB_HOST` | `--db-host` |
| `port` | `PORT` | `--port` |

### ネストキー

サポートしない。フラットなキーアクセスのみ。

## Non-Goals

- 項目別の優先度カスタマイズはライブラリ内では行わない（origin を公開し、利用側に委ねる）

## References

- convict: スキーマ宣言スタイルの参考
- @npmcli/config: `find(key)` による由来追跡の参考
- node-config Issue #217: キー単位の由来追跡が未実装で放置されている需要の証拠

## Execution Report

Piece `takt-default` completed successfully.

Closes #1