### PR TITLE
[#11] fix-pr6-review-feedback

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -47,7 +47,7 @@ describe('traced-config API contract', () => {
   it('should return default value and default origin for schema key', async () => {
     const config = await createConfig({
       schema: {
-        port: { default: 8080 },
+        port: { doc: 'test doc', default: 8080 },
       },
     });
 
@@ -63,7 +63,7 @@ describe('traced-config API contract', () => {
     const config = await createConfig({ envStyle: 'SCREAMING_SNAKE', argStyle: 'kebab' });
 
     config.addSchema({
-      host: { default: 'localhost' },
+      host: { doc: 'test doc', default: 'localhost' },
     });
 
     expect(config.get('host')).toBe('localhost');
@@ -72,12 +72,12 @@ describe('traced-config API contract', () => {
   it('should return extended typed api from addSchema', async () => {
     const config = await createConfig({
       schema: {
-        host: { default: 'localhost' },
+        host: { doc: 'test doc', default: 'localhost' },
       },
     });
 
     const extended = config.addSchema({
-      port: { default: 8080 },
+      port: { doc: 'test doc', default: 8080 },
     });
 
     const acceptsNumber = (value: number): number => value;
@@ -90,8 +90,8 @@ describe('traced-config API contract', () => {
   it('should infer get return types from schema default values', async () => {
     const config = await createConfig({
       schema: {
-        port: { default: 8080 },
-        host: { default: 'localhost' },
+        port: { doc: 'test doc', default: 8080 },
+        host: { doc: 'test doc', default: 'localhost' },
       },
     });
 
@@ -107,19 +107,19 @@ describe('traced-config API contract', () => {
   it('should throw when addSchema defines duplicate key', async () => {
     const config = await createConfig({
       schema: {
-        port: { default: 8080 },
+        port: { doc: 'test doc', default: 8080 },
       },
     });
 
     expect(() => {
       config.addSchema({
-        port: { default: 3000 },
+        port: { doc: 'test doc', default: 3000 },
       });
     }).toThrow(/Schema key 'port' is already defined/);
   });
 
   it('should throw when get is called with undefined schema key', async () => {
-    const config = await createConfig({ schema: { port: { default: 8080 } } });
+    const config = await createConfig({ schema: { port: { doc: 'test doc', default: 8080 } } });
 
     expect(() => config.get('missingKey')).toThrow();
   });
@@ -129,19 +129,39 @@ describe('traced-config API contract', () => {
 
     expect(() => {
       config.addSchema({
-        'db.host': { default: 'localhost' },
+        'db.host': { doc: 'test doc', default: 'localhost' },
       });
     }).toThrow();
   });
 
+  it('should throw when schema entry doc is missing', async () => {
+    const config = await createConfig({});
+
+    expect(() => {
+      config.addSchema({
+        port: { default: 8080 } as unknown as { doc: string; default: number },
+      });
+    }).toThrow(/must define a non-empty doc string/);
+  });
+
+  it('should throw when schema entry doc is empty', async () => {
+    const config = await createConfig({});
+
+    expect(() => {
+      config.addSchema({
+        port: { doc: '   ', default: 8080 },
+      });
+    }).toThrow(/must define a non-empty doc string/);
+  });
+
   it('should require object entries with label in loadFile', async () => {
-    const config = await createConfig({ schema: { port: { default: 8080 } } });
+    const config = await createConfig({ schema: { port: { doc: 'test doc', default: 8080 } } });
 
     await expect(config.loadFile(['./config.yaml' as unknown as { path: string; label: 'global' | 'local' }])).rejects.toThrow();
   });
 
   it('should skip missing files in loadFile', async () => {
-    const config = await createConfig({ schema: { port: { default: 8080 } } });
+    const config = await createConfig({ schema: { port: { doc: 'test doc', default: 8080 } } });
 
     await expect(config.loadFile([{ path: '/path/does/not/exist.yaml', label: 'global' }])).resolves.toBeUndefined();
 
@@ -157,8 +177,8 @@ describe('traced-config API contract', () => {
 
     const config = await createConfig({
       schema: {
-        port: { default: 3000 },
-        host: { default: 'localhost' },
+        port: { doc: 'test doc', default: 3000 },
+        host: { doc: 'test doc', default: 'localhost' },
       },
     });
 
@@ -182,7 +202,7 @@ describe('traced-config API contract', () => {
 
     const config = await createConfig({
       schema: {
-        port: { default: 3000, format: 'port' },
+        port: { doc: 'test doc', default: 3000, format: 'port' },
       },
     });
 
@@ -206,6 +226,7 @@ describe('traced-config API contract', () => {
     const config = await createConfig({
       schema: {
         port: {
+          doc: 'test doc',
           default: 3000,
           format: 'port',
           sources: { global: true, local: true, env: true, cli: false },
@@ -226,7 +247,7 @@ describe('traced-config API contract', () => {
     process.argv = ['node', 'test', '--port', '9191'];
     const config = await createConfig({
       schema: {
-        port: { default: 8080, format: 'port' },
+        port: { doc: 'test doc', default: 8080, format: 'port' },
       },
     });
 
@@ -243,6 +264,7 @@ describe('traced-config API contract', () => {
     const config = await createConfig({
       schema: {
         port: {
+          doc: 'test doc',
           default: 3000,
           format: 'port',
           sources: { global: true, local: true, env: true, cli: true },
@@ -255,6 +277,55 @@ describe('traced-config API contract', () => {
     expect(value).toBe(9191);
     expect(config.getOrigin('port')).toBe('cli');
     expect(config.getSource('port')).toBe('--port');
+  });
+
+  it('should cache cli values at initialization even if process.argv changes later', async () => {
+    process.argv = ['node', 'test', '--port', '9191'];
+    const config = await createConfig({
+      schema: {
+        port: {
+          doc: 'test doc',
+          default: 3000,
+          format: 'port',
+          sources: { global: true, local: true, env: true, cli: true },
+        },
+      },
+    });
+
+    process.argv = ['node', 'test', '--port', '9292'];
+
+    expect(config.get('port')).toBe(9191);
+    expect(config.getOrigin('port')).toBe('cli');
+    expect(config.getSource('port')).toBe('--port');
+  });
+
+  it('should keep cli cache isolated per tracedConfig instance', async () => {
+    process.argv = ['node', 'test', '--port', '7111'];
+    const first = await createConfig({
+      schema: {
+        port: {
+          doc: 'test doc',
+          default: 3000,
+          format: 'port',
+          sources: { global: true, local: true, env: true, cli: true },
+        },
+      },
+    });
+
+    process.argv = ['node', 'test', '--port', '7222'];
+    const second = await createConfig({
+      schema: {
+        port: {
+          doc: 'test doc',
+          default: 3000,
+          format: 'port',
+          sources: { global: true, local: true, env: true, cli: true },
+        },
+      },
+    });
+
+    expect(first.get('port')).toBe(7111);
+    expect(second.get('port')).toBe(7222);
   });
 
   it('should apply default < global < local < env < cli precedence chain', async () => {
@@ -270,6 +341,7 @@ describe('traced-config API contract', () => {
     const config = await createConfig({
       schema: {
         port: {
+          doc: 'test doc',
           default: 3000,
           format: 'port',
           sources: { global: true, local: true, env: true, cli: true },
@@ -294,6 +366,7 @@ describe('traced-config API contract', () => {
     const config = await createConfig({
       schema: {
         port: {
+          doc: 'test doc',
           default: 8080,
           format: 'port',
           sources: { global: true, local: true, env: false, cli: false },
@@ -311,7 +384,7 @@ describe('traced-config API contract', () => {
     process.env.TAKT_ANTHROPIC_API_KEY = 'env-secret';
     const config = await createConfig({
       schema: {
-        taktAnthropicApiKey: { default: '', sources: { global: true, local: true, env: true, cli: false } },
+        taktAnthropicApiKey: { doc: 'test doc', default: '', sources: { global: true, local: true, env: true, cli: false } },
       },
     });
 
@@ -329,6 +402,7 @@ describe('traced-config API contract', () => {
     const config = await createConfig({
       schema: {
         port: {
+          doc: 'test doc',
           default: 8080,
           format: 'port',
           env: 'CUSTOM_PORT',
@@ -350,6 +424,7 @@ describe('traced-config API contract', () => {
     const config = await createConfig({
       schema: {
         port: {
+          doc: 'test doc',
           default: 8080,
           format: 'port',
           arg: 'custom-port',
@@ -367,7 +442,7 @@ describe('traced-config API contract', () => {
     process.env.TAGS = 'a,b,c';
     const config = await createConfig({
       schema: {
-        tags: { default: [] as string[], format: Array, env: 'TAGS', sources: { global: true, local: true, env: true, cli: false } },
+        tags: { doc: 'test doc', default: [] as string[], format: Array, env: 'TAGS', sources: { global: true, local: true, env: true, cli: false } },
       },
     });
 
@@ -381,7 +456,7 @@ describe('traced-config API contract', () => {
     process.argv = ['node', 'test', '--tags', 'red,green,blue'];
     const config = await createConfig({
       schema: {
-        tags: { default: [] as string[], format: Array, sources: { global: true, local: true, env: true, cli: true } },
+        tags: { doc: 'test doc', default: [] as string[], format: Array, sources: { global: true, local: true, env: true, cli: true } },
       },
     });
 
@@ -396,7 +471,7 @@ describe('traced-config API contract', () => {
     process.env.PORT = '-1';
     const config = await createConfig({
       schema: {
-        port: { default: 8080, format: 'port', sources: { global: true, local: true, env: true, cli: false } },
+        port: { doc: 'test doc', default: 8080, format: 'port', sources: { global: true, local: true, env: true, cli: false } },
       },
     });
 
@@ -412,6 +487,7 @@ describe('traced-config API contract', () => {
     const config = await createConfig({
       schema: {
         nodeEnv: {
+          doc: 'test doc',
           default: 'development',
           format: ['production', 'development', 'test'],
           env: 'NODE_ENV',
@@ -433,8 +509,8 @@ describe('traced-config API contract', () => {
 
     const config = await createConfig({
       schema: {
-        port: { default: 8080, format: 'port' },
-        host: { default: 'localhost' },
+        port: { doc: 'test doc', default: 8080, format: 'port' },
+        host: { doc: 'test doc', default: 'localhost' },
       },
     });
 
@@ -462,7 +538,7 @@ describe('traced-config API contract', () => {
   it('should register custom format and validate with it', async () => {
     const config = await createConfig({
       schema: {
-        evenValue: { default: 3, format: 'isEven' },
+        evenValue: { doc: 'test doc', default: 3, format: 'isEven' },
       },
     });
 
@@ -483,7 +559,7 @@ describe('traced-config API contract', () => {
     process.env.NAT_VALUE = '-1';
     const config = await createConfig({
       schema: {
-        natValue: { default: 1, format: 'nat', env: 'NAT_VALUE', sources: { global: true, local: true, env: true, cli: false } },
+        natValue: { doc: 'test doc', default: 1, format: 'nat', env: 'NAT_VALUE', sources: { global: true, local: true, env: true, cli: false } },
       },
     });
 
@@ -498,7 +574,7 @@ describe('traced-config API contract', () => {
     process.env.INT_VALUE = '1.5';
     const config = await createConfig({
       schema: {
-        intValue: { default: 2, format: 'int', env: 'INT_VALUE', sources: { global: true, local: true, env: true, cli: false } },
+        intValue: { doc: 'test doc', default: 2, format: 'int', env: 'INT_VALUE', sources: { global: true, local: true, env: true, cli: false } },
       },
     });
 
@@ -513,7 +589,7 @@ describe('traced-config API contract', () => {
     process.env.APP_URL = 'not-a-url';
     const config = await createConfig({
       schema: {
-        appUrl: { default: 'https://example.com', format: 'url', env: 'APP_URL', sources: { global: true, local: true, env: true, cli: false } },
+        appUrl: { doc: 'test doc', default: 'https://example.com', format: 'url', env: 'APP_URL', sources: { global: true, local: true, env: true, cli: false } },
       },
     });
 
@@ -528,7 +604,7 @@ describe('traced-config API contract', () => {
     process.env.HOST_IP = '999.1.1.1';
     const config = await createConfig({
       schema: {
-        hostIp: { default: '127.0.0.1', format: 'ipaddress', env: 'HOST_IP', sources: { global: true, local: true, env: true, cli: false } },
+        hostIp: { doc: 'test doc', default: '127.0.0.1', format: 'ipaddress', env: 'HOST_IP', sources: { global: true, local: true, env: true, cli: false } },
       },
     });
 
@@ -546,13 +622,14 @@ describe('traced-config API contract', () => {
 
     const config = await createConfig({
       schema: {
-        port: { default: 3000, format: 'port' },
+        port: { doc: 'test doc', default: 3000, format: 'port' },
       },
     });
     await config.loadFile([{ path: globalFile, label: 'global' }]);
 
     const errors = config.validate({ strict: true });
 
+    expect(errors.every((error) => typeof error.message === 'string')).toBe(true);
     expect(errors).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ key: 'typoKey', source: globalFile, origin: 'global' }),
@@ -569,7 +646,7 @@ describe('traced-config API contract', () => {
 
     const config = await createConfig({
       schema: {
-        port: { default: 3000, format: 'port' },
+        port: { doc: 'test doc', default: 3000, format: 'port' },
       },
     });
     await config.loadFile([{ path: localFile, label: 'local' }]);

--- a/src/__tests__/types-contract.test.ts
+++ b/src/__tests__/types-contract.test.ts
@@ -1,0 +1,34 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+
+async function readTypesSource(): Promise<string> {
+  return readFile(new URL('../types.ts', import.meta.url), 'utf8');
+}
+
+function extractTypeBlock(source: string, typeName: string): string {
+  const pattern = new RegExp(`export type ${typeName}[^=]*= \\{([\\s\\S]*?)\\n\\};`);
+  const match = source.match(pattern);
+  if (!match) {
+    throw new Error(`Unable to find type block: ${typeName}`);
+  }
+
+  return match[1];
+}
+
+describe('types contract', () => {
+  it('should require doc metadata in SchemaEntry', async () => {
+    const source = await readTypesSource();
+    const schemaEntryBlock = extractTypeBlock(source, 'SchemaEntry');
+
+    expect(schemaEntryBlock).toMatch(/\bdoc: string;/);
+    expect(schemaEntryBlock).not.toMatch(/\bdoc\?: string;/);
+  });
+
+  it('should require message in ValidateError', async () => {
+    const source = await readTypesSource();
+    const validateErrorBlock = extractTypeBlock(source, 'ValidateError');
+
+    expect(validateErrorBlock).toMatch(/\bmessage: string;/);
+    expect(validateErrorBlock).not.toMatch(/\bmessage\?: string;/);
+  });
+});

--- a/src/__tests__/validation.test.ts
+++ b/src/__tests__/validation.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { coerceInputValue } from '../validation.js';
+import type { ResolvedSchemaEntry } from '../types.js';
+
+function createEntry(overrides: Partial<ResolvedSchemaEntry>): ResolvedSchemaEntry {
+  return {
+    doc: 'test doc',
+    default: '',
+    env: 'DUMMY_ENV',
+    arg: 'dummy-arg',
+    sources: { global: true, local: true, env: true, cli: true },
+    ...overrides,
+  };
+}
+
+describe('coerceInputValue', () => {
+  it('should coerce numeric strings consistently for format and default fallbacks', () => {
+    const formatEntry = createEntry({ default: '0', format: 'int' });
+    const defaultEntry = createEntry({ default: 0, format: undefined });
+
+    const fromFormat = coerceInputValue('42', formatEntry);
+    const fromDefault = coerceInputValue('42', defaultEntry);
+
+    expect(fromFormat).toBe(42);
+    expect(fromDefault).toBe(42);
+  });
+
+  it('should preserve original string when numeric coercion fails', () => {
+    const formatEntry = createEntry({ default: 0, format: 'port' });
+    const defaultEntry = createEntry({ default: 0, format: undefined });
+
+    const fromFormat = coerceInputValue('invalid-number', formatEntry);
+    const fromDefault = coerceInputValue('invalid-number', defaultEntry);
+
+    expect(fromFormat).toBe('invalid-number');
+    expect(fromDefault).toBe('invalid-number');
+  });
+
+  it('should coerce boolean strings consistently for format and default fallbacks', () => {
+    const formatEntry = createEntry({ default: true, format: Boolean });
+    const defaultEntry = createEntry({ default: true, format: undefined });
+
+    const truthyFromFormat = coerceInputValue('1', formatEntry);
+    const falsyFromFormat = coerceInputValue('false', formatEntry);
+    const truthyFromDefault = coerceInputValue('1', defaultEntry);
+    const falsyFromDefault = coerceInputValue('false', defaultEntry);
+
+    expect(truthyFromFormat).toBe(true);
+    expect(falsyFromFormat).toBe(false);
+    expect(truthyFromDefault).toBe(true);
+    expect(falsyFromDefault).toBe(false);
+  });
+
+  it('should split comma-separated strings consistently for format and default fallbacks', () => {
+    const formatEntry = createEntry({ default: ['x'], format: Array });
+    const defaultEntry = createEntry({ default: ['x'], format: undefined });
+
+    const fromFormat = coerceInputValue('red, green, blue', formatEntry);
+    const fromDefault = coerceInputValue('red, green, blue', defaultEntry);
+
+    expect(fromFormat).toEqual(['red', 'green', 'blue']);
+    expect(fromDefault).toEqual(['red', 'green', 'blue']);
+  });
+});

--- a/src/traced-config.ts
+++ b/src/traced-config.ts
@@ -39,6 +39,7 @@ export function tracedConfig<TSchema extends SchemaShape = {}>(
   const unknownFileKeys: UnknownKeyIssue[] = [];
   const parsers = createDefaultParsers();
   const customFormats = new Map<string, FormatValidator>();
+  const cachedCliValues = parseCli(process.argv);
 
   function assertKnownKey(key: string): ResolvedSchemaEntry {
     const entry = schema.get(key);
@@ -84,8 +85,7 @@ export function tracedConfig<TSchema extends SchemaShape = {}>(
     }
 
     if (entry.sources.cli) {
-      const cliValues = parseCli(process.argv);
-      const cliValue = cliValues.get(entry.arg);
+      const cliValue = cachedCliValues.get(entry.arg);
       if (cliValue) {
         traced = {
           value: coerceInputValue(cliValue.value, entry),
@@ -110,6 +110,10 @@ export function tracedConfig<TSchema extends SchemaShape = {}>(
         throw new Error(`Schema key '${key}' is already defined`);
       }
 
+      if (typeof rawEntry.doc !== 'string' || rawEntry.doc.trim().length === 0) {
+        throw new Error(`Schema key '${key}' must define a non-empty doc string`);
+      }
+
       const env = rawEntry.env ?? buildDefaultEnvName(key, envStyle);
       const arg = rawEntry.arg ?? buildDefaultArgName(key, argStyle);
       const sources: SourceToggles = {
@@ -119,6 +123,7 @@ export function tracedConfig<TSchema extends SchemaShape = {}>(
 
       schema.set(key, {
         default: rawEntry.default,
+        doc: rawEntry.doc,
         format: rawEntry.format,
         env,
         arg: normalizeArgName(arg),

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,6 +10,7 @@ export type SourceToggles = {
 
 export type SchemaEntry<TDefault> = {
   default: TDefault;
+  doc: string;
   format?: unknown;
   env?: string;
   arg?: string;
@@ -30,10 +31,10 @@ export type TracedValue<TValue> = {
 
 export type ValidateError = {
   key: string;
+  message: string;
   value?: unknown;
   source?: string | null;
   origin?: string;
-  message?: string;
 };
 
 export type TracedConfigOptions<TSchema extends SchemaShape = {}> = {
@@ -47,6 +48,7 @@ export type FormatValidator = (value: unknown) => boolean;
 
 export type ResolvedSchemaEntry = {
   default: unknown;
+  doc: string;
   format?: unknown;
   env: string;
   arg: string;

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,29 +1,41 @@
 import type { ResolvedSchemaEntry, ValidateError } from './types.js';
 
+function coerceNumberString(value: string): number | string {
+  const parsed = Number(value);
+  return Number.isNaN(parsed) ? value : parsed;
+}
+
+function coerceBooleanString(value: string): boolean | string {
+  if (value === 'true' || value === '1') {
+    return true;
+  }
+
+  if (value === 'false' || value === '0') {
+    return false;
+  }
+
+  return value;
+}
+
+function coerceArrayString(value: string): string[] {
+  return value.split(',').map((part) => part.trim());
+}
+
 export function coerceInputValue(value: unknown, entry: ResolvedSchemaEntry): unknown {
   if (typeof value !== 'string') {
     return value;
   }
 
   if (entry.format === Array) {
-    return value.split(',').map((part) => part.trim());
+    return coerceArrayString(value);
   }
 
   if (entry.format === Number || entry.format === 'port' || entry.format === 'nat' || entry.format === 'int') {
-    const parsed = Number(value);
-    return Number.isNaN(parsed) ? value : parsed;
+    return coerceNumberString(value);
   }
 
   if (entry.format === Boolean) {
-    if (value === 'true' || value === '1') {
-      return true;
-    }
-
-    if (value === 'false' || value === '0') {
-      return false;
-    }
-
-    return value;
+    return coerceBooleanString(value);
   }
 
   if (entry.format === String) {
@@ -31,22 +43,15 @@ export function coerceInputValue(value: unknown, entry: ResolvedSchemaEntry): un
   }
 
   if (Array.isArray(entry.default)) {
-    return value.split(',').map((part) => part.trim());
+    return coerceArrayString(value);
   }
 
   if (typeof entry.default === 'number') {
-    const parsed = Number(value);
-    return Number.isNaN(parsed) ? value : parsed;
+    return coerceNumberString(value);
   }
 
   if (typeof entry.default === 'boolean') {
-    if (value === 'true' || value === '1') {
-      return true;
-    }
-
-    if (value === 'false' || value === '0') {
-      return false;
-    }
+    return coerceBooleanString(value);
   }
 
   return value;


### PR DESCRIPTION
## Summary

PR #6 のコードレビューで見つかった改善点。

## 1. parseCli を毎回パースしている

`traced-config.ts:781` の `resolveKey` 内で `get()` を呼ぶたびに `parseCli(process.argv)` を実行している。初期化時に1回パースしてキャッシュすべき。

## 2. SchemaEntry に doc フィールドがない

仕様では `doc` フィールドが定義されているが、`types.ts` の `SchemaEntry` 型に含まれていない。

## 3. ValidateError の型が曖昧

全フィールドが optional で、フォーマットエラーと未定義キーエラーの構造が区別できない。discriminated union にするか、最低限 `message` を必須にすべき。

## 4. coerceInputValue のフォールバック重複

format による分岐と default の型による分岐で同じ変換ロジックが2箇所に書かれている。ヘルパー関数に共通化すべき。

## Execution Report

Piece `takt-default` completed successfully.

Closes #11