### PR TITLE
Release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.0] - 2026-03-26
+
+### Added
+- ネストされたスキーマキーのサポート: `db.host` のようなドット区切りキーを `addSchema()` で定義可能に (#16)
+- 設定ファイルのネスト構造自動フラット化: YAML/JSON の階層構造をスキーマのドットキーに自動マッピング (#16)
+- プレフィックス衝突検出: `db` と `db.host` のように親子関係のあるキーを同時に定義した場合にエラーを報告 (#16)
+
+### Changed
+- 命名変換（env/arg 自動生成）がドット区切りキーに対応: `db.host` → `DB_HOST`（env）/ `--db-host`（arg） (#16)
+
 ## [0.1.0] - 2026-03-09
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "traced-config",
-  "version": "0.0.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "traced-config",
-      "version": "0.0.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.8.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "traced-config",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Configuration management with key-level source tracing. Know where every value came from.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Changes

### Added
- ネストされたスキーマキーのサポート: `db.host` のようなドット区切りキーを `addSchema()` で定義可能に (#16)
- 設定ファイルのネスト構造自動フラット化: YAML/JSON の階層構造をスキーマのドットキーに自動マッピング (#16)
- プレフィックス衝突検出: `db` と `db.host` のように親子関係のあるキーを同時に定義した場合にエラーを報告 (#16)

### Changed
- 命名変換（env/arg 自動生成）がドット区切りキーに対応: `db.host` → `DB_HOST`（env）/ `--db-host`（arg） (#16)

## Commits

- 559b1ab Merge pull request #17 from nrslib/takt/16/add-nested-schema-keys
- 49c003b takt: fix-schema-prefix-collision
- bac31c9 takt: add-nested-schema-keys
- f714be3 Release v0.2.0