### PR TITLE
[#19] add-global-source-toggles

### DIFF
--- a/src/__tests__/architecture-contract.test.ts
+++ b/src/__tests__/architecture-contract.test.ts
@@ -1,0 +1,11 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it } from 'vitest';
+
+describe('architecture contract', () => {
+  it('should keep traced-config entrypoint within the file size limit', async () => {
+    const source = await readFile(new URL('../traced-config.ts', import.meta.url), 'utf8');
+    const lineCount = source.trimEnd().split('\n').length;
+
+    expect(lineCount).toBeLessThanOrEqual(300);
+  });
+});

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -462,6 +462,98 @@ describe('traced-config API contract', () => {
     expect(config.getOrigin('port')).toBe('default');
   });
 
+  it('should disable env and cli globally through defaultSources', async () => {
+    process.env.PORT = '7070';
+    process.argv = ['node', 'test', '--port', '9191'];
+
+    const config = await createConfig({
+      defaultSources: {
+        env: false,
+        cli: false,
+      },
+      schema: {
+        port: {
+          doc: 'test doc',
+          default: 3000,
+          format: 'port',
+        },
+      },
+    });
+
+    expect(config.get('port')).toBe(3000);
+    expect(config.getOrigin('port')).toBe('default');
+    expect(config.getSource('port')).toBeNull();
+  });
+
+  it('should allow schema sources to override global defaultSources', async () => {
+    process.env.PORT = '7070';
+    process.argv = ['node', 'test', '--port', '9191'];
+
+    const config = await createConfig({
+      defaultSources: {
+        env: false,
+        cli: false,
+      },
+      schema: {
+        port: {
+          doc: 'test doc',
+          default: 3000,
+          format: 'port',
+          sources: { env: true },
+        },
+      },
+    });
+
+    expect(config.get('port')).toBe(7070);
+    expect(config.getOrigin('port')).toBe('env');
+    expect(config.getSource('port')).toBe('PORT');
+  });
+
+  it('should enable cli globally through defaultSources when requested', async () => {
+    process.env.PORT = '7070';
+    process.argv = ['node', 'test', '--port', '9191'];
+
+    const config = await createConfig({
+      defaultSources: {
+        cli: true,
+      },
+      schema: {
+        port: {
+          doc: 'test doc',
+          default: 3000,
+          format: 'port',
+        },
+      },
+    });
+
+    expect(config.get('port')).toBe(9191);
+    expect(config.getOrigin('port')).toBe('cli');
+    expect(config.getSource('port')).toBe('--port');
+  });
+
+  it('should apply defaultSources to schema added after initialization', async () => {
+    process.env.PORT = '7070';
+    process.argv = ['node', 'test', '--port', '9191'];
+
+    const config = await createConfig({
+      defaultSources: {
+        env: false,
+        cli: false,
+      },
+    });
+
+    config.addSchema({
+      port: {
+        doc: 'test doc',
+        default: 3000,
+        format: 'port',
+      },
+    });
+
+    expect(config.get('port')).toBe(3000);
+    expect(config.getOrigin('port')).toBe('default');
+  });
+
   it('should prioritize cli over env when cli source is enabled', async () => {
     process.env.PORT = '7070';
     process.argv = ['node', 'test', '--port', '9191'];
@@ -872,6 +964,36 @@ describe('traced-config API contract', () => {
         env: 'CUSTOM_PORT',
         arg: 'custom-port',
         sources: { global: true, local: true, env: true, cli: true },
+      },
+    });
+  });
+
+  it('should expose merged defaultSources in schema metadata', async () => {
+    const config = await createConfig({
+      defaultSources: {
+        env: false,
+        cli: false,
+      },
+      schema: {
+        port: {
+          doc: 'Port used by the server',
+          default: 8080,
+          format: 'port',
+        },
+        host: {
+          doc: 'Host used by the server',
+          default: 'localhost',
+          sources: { cli: true },
+        },
+      },
+    });
+
+    expect(config.getSchema()).toMatchObject({
+      port: {
+        sources: { global: true, local: true, env: false, cli: false },
+      },
+      host: {
+        sources: { global: true, local: true, env: false, cli: true },
       },
     });
   });

--- a/src/__tests__/types-contract.test.ts
+++ b/src/__tests__/types-contract.test.ts
@@ -16,6 +16,13 @@ function extractTypeBlock(source: string, typeName: string): string {
 }
 
 describe('types contract', () => {
+  it('should expose defaultSources in TracedConfigOptions', async () => {
+    const source = await readTypesSource();
+    const optionsBlock = extractTypeBlock(source, 'TracedConfigOptions');
+
+    expect(optionsBlock).toMatch(/\bdefaultSources\?: Partial<Pick<SourceToggles, 'env' \| 'cli'>>;/);
+  });
+
   it('should require doc metadata in SchemaEntry', async () => {
     const source = await readTypesSource();
     const schemaEntryBlock = extractTypeBlock(source, 'SchemaEntry');

--- a/src/traced-config-files.ts
+++ b/src/traced-config-files.ts
@@ -1,0 +1,85 @@
+import { constants } from 'node:fs';
+import { access, readFile } from 'node:fs/promises';
+import { createDefaultParsers, flattenFileEntries, getFileExtension, isMissingFileError, isPlainObject } from './utils.js';
+import type { FileLabel, FileParser, FileValueRecord, UnknownKeyIssue } from './types.js';
+
+export type LoadFileEntry = {
+  path: string;
+  label: FileLabel;
+};
+
+type FileValueStores = {
+  globalValues: Map<string, FileValueRecord>;
+  localValues: Map<string, FileValueRecord>;
+};
+
+export function createParserRegistry(): Map<string, FileParser> {
+  return createDefaultParsers();
+}
+
+function assertLoadFileEntry(entry: LoadFileEntry): void {
+  if (!isPlainObject(entry) || typeof entry.path !== 'string' || (entry.label !== 'global' && entry.label !== 'local')) {
+    throw new Error('loadFile entries must be objects with { path, label } where label is global or local');
+  }
+}
+
+function assignFileValue(
+  label: FileLabel,
+  key: string,
+  value: unknown,
+  source: string,
+  stores: FileValueStores,
+): void {
+  if (label === 'global') {
+    stores.globalValues.set(key, { value, source });
+    return;
+  }
+
+  stores.localValues.set(key, { value, source });
+}
+
+export async function loadConfigFiles(
+  entries: LoadFileEntry[],
+  schemaKeys: ReadonlySet<string>,
+  parsers: ReadonlyMap<string, FileParser>,
+  stores: FileValueStores,
+  unknownFileKeys: UnknownKeyIssue[],
+): Promise<void> {
+  for (const entry of entries) {
+    assertLoadFileEntry(entry);
+
+    try {
+      await access(entry.path, constants.F_OK);
+    } catch (error) {
+      if (isMissingFileError(error)) {
+        continue;
+      }
+
+      throw error;
+    }
+
+    const content = await readFile(entry.path, 'utf8');
+    const extension = getFileExtension(entry.path);
+    const parser = parsers.get(extension);
+    if (!parser) {
+      throw new Error(`Unsupported file type for path: ${entry.path}`);
+    }
+
+    let parsedRaw: unknown;
+    try {
+      parsedRaw = parser(content);
+    } catch {
+      throw new Error(`Failed to parse config file '${entry.path}' (label: ${entry.label})`);
+    }
+
+    const parsedEntries = isPlainObject(parsedRaw) ? flattenFileEntries(parsedRaw, schemaKeys) : [];
+    for (const [key, value] of parsedEntries) {
+      if (!schemaKeys.has(key)) {
+        unknownFileKeys.push({ key, source: entry.path, origin: entry.label });
+        continue;
+      }
+
+      assignFileValue(entry.label, key, value, entry.path, stores);
+    }
+  }
+}

--- a/src/traced-config-resolution.ts
+++ b/src/traced-config-resolution.ts
@@ -1,0 +1,46 @@
+import { coerceInputValue } from './validation.js';
+import type { CliValue, FileValueRecord, ResolvedSchemaEntry, TracedValue } from './types.js';
+
+export function resolveSchemaValue(
+  entry: ResolvedSchemaEntry,
+  globalValues: ReadonlyMap<string, FileValueRecord>,
+  localValues: ReadonlyMap<string, FileValueRecord>,
+  cachedCliValues: ReadonlyMap<string, CliValue>,
+  key: string,
+): TracedValue<unknown> {
+  let traced: TracedValue<unknown> = {
+    value: entry.default,
+    source: null,
+    origin: 'default',
+  };
+
+  const globalValue = entry.sources.global ? globalValues.get(key) : undefined;
+  if (globalValue) {
+    traced = { value: globalValue.value, source: globalValue.source, origin: 'global' };
+  }
+
+  const localValue = entry.sources.local ? localValues.get(key) : undefined;
+  if (localValue) {
+    traced = { value: localValue.value, source: localValue.source, origin: 'local' };
+  }
+
+  const envValue = entry.sources.env ? process.env[entry.env] : undefined;
+  if (envValue !== undefined) {
+    traced = {
+      value: coerceInputValue(envValue, entry),
+      source: entry.env,
+      origin: 'env',
+    };
+  }
+
+  const cliValue = entry.sources.cli ? cachedCliValues.get(entry.arg) : undefined;
+  if (cliValue) {
+    traced = {
+      value: coerceInputValue(cliValue.value, entry),
+      source: cliValue.source,
+      origin: 'cli',
+    };
+  }
+
+  return traced;
+}

--- a/src/traced-config-schema.ts
+++ b/src/traced-config-schema.ts
@@ -1,0 +1,60 @@
+import { buildDefaultArgName, buildDefaultEnvName, normalizeArgName } from './naming.js';
+import type { ResolvedSchemaEntry, SchemaEntry, SourceToggles } from './types.js';
+
+export const DEFAULT_SOURCES: SourceToggles = {
+  global: true,
+  local: true,
+  env: true,
+  cli: false,
+};
+
+export function createDefaultSchemaSources(
+  defaultSources: Partial<Pick<SourceToggles, 'env' | 'cli'>> | undefined,
+): SourceToggles {
+  return {
+    ...DEFAULT_SOURCES,
+    env: defaultSources?.env ?? DEFAULT_SOURCES.env,
+    cli: defaultSources?.cli ?? DEFAULT_SOURCES.cli,
+  };
+}
+
+export function findPrefixCollision(key: string, keys: Iterable<string>): string | null {
+  for (const existingKey of keys) {
+    if (key.startsWith(`${existingKey}.`) || existingKey.startsWith(`${key}.`)) {
+      return existingKey;
+    }
+  }
+
+  return null;
+}
+
+function assertDocString(key: string, entry: SchemaEntry<unknown>): void {
+  if (typeof entry.doc !== 'string' || entry.doc.trim().length === 0) {
+    throw new Error(`Schema key '${key}' must define a non-empty doc string`);
+  }
+}
+
+export function resolveSchemaEntry(
+  key: string,
+  entry: SchemaEntry<unknown>,
+  envStyle: 'SCREAMING_SNAKE',
+  argStyle: 'kebab',
+  defaultSources: SourceToggles,
+): ResolvedSchemaEntry {
+  assertDocString(key, entry);
+
+  const env = entry.env ?? buildDefaultEnvName(key, envStyle);
+  const arg = entry.arg ?? buildDefaultArgName(key, argStyle);
+
+  return {
+    default: entry.default,
+    doc: entry.doc,
+    format: entry.format,
+    env,
+    arg: normalizeArgName(arg),
+    sources: {
+      ...defaultSources,
+      ...(entry.sources ?? {}),
+    },
+  };
+}

--- a/src/traced-config.ts
+++ b/src/traced-config.ts
@@ -1,9 +1,8 @@
-import { access, readFile } from 'node:fs/promises';
-import { constants } from 'node:fs';
 import { parseCli } from './cli.js';
-import { buildDefaultArgName, buildDefaultEnvName, normalizeArgName } from './naming.js';
+import { loadConfigFiles, createParserRegistry, type LoadFileEntry } from './traced-config-files.js';
+import { resolveSchemaValue } from './traced-config-resolution.js';
+import { createDefaultSchemaSources, findPrefixCollision, resolveSchemaEntry } from './traced-config-schema.js';
 import type {
-  FileLabel,
   FileParser,
   FileValueRecord,
   FormatValidator,
@@ -11,33 +10,25 @@ import type {
   Origin,
   ResolvedSchemaEntry,
   SchemaShape,
-  SourceToggles,
   TracedConfigApi,
   TracedConfigOptions,
   TracedValue,
   UnknownKeyIssue,
   ValidateError,
 } from './types.js';
-import { createDefaultParsers, flattenFileEntries, getFileExtension, isMissingFileError, isPlainObject } from './utils.js';
-import { coerceInputValue, isBuiltinStringFormat, validateFormatValue } from './validation.js';
-
-const DEFAULT_SOURCES: SourceToggles = {
-  global: true,
-  local: true,
-  env: true,
-  cli: false,
-};
+import { isBuiltinStringFormat, validateFormatValue } from './validation.js';
 
 export function tracedConfig<TSchema extends SchemaShape = {}>(
   options: TracedConfigOptions<TSchema> = {},
 ): TracedConfigApi<InferSchemaValues<TSchema>> {
   const envStyle = options.envStyle ?? 'SCREAMING_SNAKE';
   const argStyle = options.argStyle ?? 'kebab';
+  const defaultSchemaSources = createDefaultSchemaSources(options.defaultSources);
   const schema = new Map<string, ResolvedSchemaEntry>();
   const globalValues = new Map<string, FileValueRecord>();
   const localValues = new Map<string, FileValueRecord>();
   const unknownFileKeys: UnknownKeyIssue[] = [];
-  const parsers = createDefaultParsers();
+  const parsers = createParserRegistry();
   const customFormats = new Map<string, FormatValidator>();
   const cachedCliValues = parseCli(process.argv);
 
@@ -50,62 +41,9 @@ export function tracedConfig<TSchema extends SchemaShape = {}>(
     return entry;
   }
 
-  function findPrefixCollision(key: string, keys: Iterable<string>): string | null {
-    for (const existingKey of keys) {
-      if (key.startsWith(`${existingKey}.`) || existingKey.startsWith(`${key}.`)) {
-        return existingKey;
-      }
-    }
-
-    return null;
-  }
-
   function resolveKey(key: string): TracedValue<unknown> {
     const entry = assertKnownKey(key);
-
-    let traced: TracedValue<unknown> = {
-      value: entry.default,
-      source: null,
-      origin: 'default',
-    };
-
-    if (entry.sources.global) {
-      const fromGlobal = globalValues.get(key);
-      if (fromGlobal) {
-        traced = { value: fromGlobal.value, source: fromGlobal.source, origin: 'global' };
-      }
-    }
-
-    if (entry.sources.local) {
-      const fromLocal = localValues.get(key);
-      if (fromLocal) {
-        traced = { value: fromLocal.value, source: fromLocal.source, origin: 'local' };
-      }
-    }
-
-    if (entry.sources.env) {
-      const envValue = process.env[entry.env];
-      if (envValue !== undefined) {
-        traced = {
-          value: coerceInputValue(envValue, entry),
-          source: entry.env,
-          origin: 'env',
-        };
-      }
-    }
-
-    if (entry.sources.cli) {
-      const cliValue = cachedCliValues.get(entry.arg);
-      if (cliValue) {
-        traced = {
-          value: coerceInputValue(cliValue.value, entry),
-          source: cliValue.source,
-          origin: 'cli',
-        };
-      }
-    }
-
-    return traced;
+    return resolveSchemaValue(entry, globalValues, localValues, cachedCliValues, key);
   }
 
   function addSchema<TNextSchema extends SchemaShape>(
@@ -126,25 +64,8 @@ export function tracedConfig<TSchema extends SchemaShape = {}>(
         throw new Error(`Schema key '${key}' has a prefix collision with existing key '${collidedKey}'`);
       }
 
-      if (typeof rawEntry.doc !== 'string' || rawEntry.doc.trim().length === 0) {
-        throw new Error(`Schema key '${key}' must define a non-empty doc string`);
-      }
-
-      const env = rawEntry.env ?? buildDefaultEnvName(key, envStyle);
-      const arg = rawEntry.arg ?? buildDefaultArgName(key, argStyle);
-      const sources: SourceToggles = {
-        ...DEFAULT_SOURCES,
-        ...(rawEntry.sources ?? {}),
-      };
-
-      pendingEntries.push([key, {
-        default: rawEntry.default,
-        doc: rawEntry.doc,
-        format: rawEntry.format,
-        env,
-        arg: normalizeArgName(arg),
-        sources,
-      }]);
+      const resolvedEntry = resolveSchemaEntry(key, rawEntry, envStyle, argStyle, defaultSchemaSources);
+      pendingEntries.push([key, resolvedEntry]);
     }
 
     for (const [key, entry] of pendingEntries) {
@@ -179,50 +100,14 @@ export function tracedConfig<TSchema extends SchemaShape = {}>(
     customFormats.set(name, validator);
   }
 
-  async function loadFile(entries: Array<{ path: string; label: FileLabel }>): Promise<void> {
-    for (const entry of entries) {
-      if (!isPlainObject(entry) || typeof entry.path !== 'string' || (entry.label !== 'global' && entry.label !== 'local')) {
-        throw new Error('loadFile entries must be objects with { path, label } where label is global or local');
-      }
-
-      try {
-        await access(entry.path, constants.F_OK);
-      } catch (error) {
-        if (isMissingFileError(error)) {
-          continue;
-        }
-
-        throw error;
-      }
-
-      const content = await readFile(entry.path, 'utf8');
-      const extension = getFileExtension(entry.path);
-      const parser = parsers.get(extension);
-      if (!parser) {
-        throw new Error(`Unsupported file type for path: ${entry.path}`);
-      }
-
-      let parsedRaw: unknown;
-      try {
-        parsedRaw = parser(content);
-      } catch {
-        throw new Error(`Failed to parse config file '${entry.path}' (label: ${entry.label})`);
-      }
-      const parsedEntries = isPlainObject(parsedRaw) ? flattenFileEntries(parsedRaw, new Set(schema.keys())) : [];
-
-      for (const [key, value] of parsedEntries) {
-        if (!schema.has(key)) {
-          unknownFileKeys.push({ key, source: entry.path, origin: entry.label });
-          continue;
-        }
-
-        if (entry.label === 'global') {
-          globalValues.set(key, { value, source: entry.path });
-        } else {
-          localValues.set(key, { value, source: entry.path });
-        }
-      }
-    }
+  async function loadFile(entries: LoadFileEntry[]): Promise<void> {
+    await loadConfigFiles(
+      entries,
+      new Set(schema.keys()),
+      parsers,
+      { globalValues, localValues },
+      unknownFileKeys,
+    );
   }
 
   function get(key: string): unknown {

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,7 @@ export type ValidateError = {
 export type TracedConfigOptions<TSchema extends SchemaShape = {}> = {
   envStyle?: 'SCREAMING_SNAKE';
   argStyle?: 'kebab';
+  defaultSources?: Partial<Pick<SourceToggles, 'env' | 'cli'>>;
   schema?: TSchema;
 };
 


### PR DESCRIPTION
## Summary

## Summary
Currently `traced-config` can disable `env` and `cli` only per schema key via `sources`.

## Problem
For applications that want to forbid `env` or `cli` overrides globally, repeating the same `sources` settings on every schema entry is verbose and error-prone. It is easy to forget to disable a source on a newly added key.

## Proposal
Add top-level options on `tracedConfig()` to control default source toggles globally.

Example direction:

```ts
const config = tracedConfig({
  defaultSources: {
    env: false,
    cli: false,
  },
  schema: {
    port: { doc: "server port", default: 3000 },
  },
});
```

Schema-level `sources` should still be able to override the global defaults when needed.

## Expected behavior
- Avoid repeating `sources: { env: false, cli: false }` on every key
- Keep per-key overrides available
- Preserve the current precedence model

## Notes
Current behavior supports per-key control only:
- `cli` is disabled by default
- `env` is enabled by default
- `.env` loaded via `loadFile()` is file input, not `process.env` input


## Execution Report

Piece `takt-default` completed successfully.

Closes #19