### PR TITLE
Release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0] - 2026-03-28
+
+### Added
+- `tracedConfig()` のトップレベル `defaultSources` を追加し、`env` / `cli` ソースの既定有効・無効を全キー一括で設定可能に (#19)
+- `getSchema()` に `defaultSources` を反映したマージ後の `sources` 情報を含め、実際に評価されるソース設定を確認可能に (#19)
+
+### Internal
+- `traced-config` の内部処理を schema 解決・値解決・ファイル読み込みに分割し、責務を整理 (#19)
+- エントリポイントの構造制約テストと `defaultSources` 契約テストを追加し、回帰検知を強化 (#19)
+
 ## [0.2.0] - 2026-03-26
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "traced-config",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "traced-config",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "yaml": "^2.8.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "traced-config",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Configuration management with key-level source tracing. Know where every value came from.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Changes

### Added
- `tracedConfig()` のトップレベル `defaultSources` を追加し、`env` / `cli` ソースの既定有効・無効を全キー一括で設定可能に (#19)
- `getSchema()` に `defaultSources` を反映したマージ後の `sources` 情報を含め、実際に評価されるソース設定を確認可能に (#19)

### Internal
- `traced-config` の内部処理を schema 解決・値解決・ファイル読み込みに分割し、責務を整理 (#19)
- エントリポイントの構造制約テストと `defaultSources` 契約テストを追加し、回帰検知を強化 (#19)

## Commits

- 1c2ac70 Merge pull request #20 from nrslib/takt/19/add-global-source-toggles
- 858b2d9 takt: add-global-source-toggles
- 8af7216 Release v0.3.0